### PR TITLE
Refined CLI and added options

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Compatibility checker for OpenAPI
 Usage: openapi-diff (-c|--client ARG) (-s|--server ARG)
                     [--silent | --only-breaking | --all] [-o|--output ARG]
                     [--folding-block-quotes-style | --header-style]
+                    [--signal-exit-code]
   A tool to check compatibility between two OpenApi specifications.
 
   Usage examples
@@ -43,7 +44,8 @@ Available options:
   -s,--server ARG          A path to the file containing the specification that
                            will be used for the server of the API. Can be either
                            a YAML or JSON file.
-  --silent                 Silence all output.
+  --silent                 Silence all output. Only makes sense in combination
+                           with --signal-exit-code.
   --only-breaking          Only report breaking changes in the output.
   --all                    Report both incompatible and compatible changes.
                            Compatible changes will not trigger a failure exit
@@ -67,4 +69,9 @@ Available options:
                            format. Markdown has rendering bugs on GitHub.
   --header-style           The report tree is structured using increasing levels
                            of headers.
+  --signal-exit-code       Signal API compatibility with the exit code.
+
+                           Exit with 0 if there are no breaking changes.
+                           Exit with 1 if there are breaking changes.
+                           Exit with 2 if could not determine compatibility.
 ```

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -49,10 +49,11 @@ main = do
   case mode opts of
     Just _ -> either handler pure <=< runExceptT $ write report
     Nothing -> pure ()
-  case status of
-    NoBreakingChanges -> exitSuccess
-    BreakingChanges -> exitWith $ ExitFailure 1
-    OnlyUnsupportedChanges -> exitWith $ ExitFailure 2
+  when (signalExitCode opts) $
+    case status of
+      NoBreakingChanges -> exitSuccess
+      BreakingChanges -> exitWith $ ExitFailure 1
+      OnlyUnsupportedChanges -> exitWith $ ExitFailure 2
 
 data Errors
   = DocumentError PandocError

--- a/app/OpenAPI/Checker/Options.hs
+++ b/app/OpenAPI/Checker/Options.hs
@@ -20,6 +20,7 @@ data Options = Options
     mode :: Maybe ReportMode
   , outputMode :: OutputMode
   , reportTreeStyle :: ReportTreeStyle
+  , signalExitCode :: Bool
   }
   deriving stock (Generic)
 
@@ -64,7 +65,7 @@ optionsParser =
     <*> (flag'
            Nothing
            (long "silent"
-              <> help "Silence all output.")
+              <> help "Silence all output. Only makes sense in combination with --signal-exit-code.")
            <|> flag'
              (Just OnlyErrors)
              (long "only-breaking"
@@ -102,6 +103,13 @@ optionsParser =
                   "The report tree is structured using \
                   \increasing levels of headers.")
            <|> pure HeadersTreeStyle)
+    <*> switch 
+        (long "signal-exit-code"
+            <> helpDoc (Just $ 
+                par "Signal API compatibility with the exit code."
+                  <$$> hardline <> par "Exit with 0 if there are no breaking changes."
+                  <$$> par "Exit with 1 if there are breaking changes."
+                  <$$> par "Exit with 2 if could not determine compatibility."))
 
 par :: String -> Doc
 par = foldr1 (</>) . fmap string . words


### PR DESCRIPTION
1. The full help is now printed on any failure
2. Only exit with failure if `--signal-exit-code` is specified.